### PR TITLE
Fix filter in DataFrames.jl

### DIFF
--- a/scripts_benchmark/dataframes.jl
+++ b/scripts_benchmark/dataframes.jl
@@ -17,7 +17,7 @@ end
 w_test("increment_map", fmap, d)
 
 ffilter = (d) -> begin
-    f = filter(row -> row.a1 < unique_values ÷ 2, d)
+    f = filter(:a1 => <(unique_values ÷ 2), d)
 end
 w_test("filter_half", ffilter, d)
 


### PR DESCRIPTION
In the original code a legacy syntax was used that is not recommended to be used because it is slow (it is kept mostly for consistency with Julia Base API).